### PR TITLE
Mejorar aspecto de las tarjetas de rango

### DIFF
--- a/commands/leveling/rank.js
+++ b/commands/leveling/rank.js
@@ -1,5 +1,6 @@
 const { Error } = require('../../modules/constructor/messageBuilder')
-const { getMember, generateRankCard } = require('../../modules/levels')
+const { getMember } = require('../../modules/levels')
+const { generateRankCard } = require('../../modules/canvasProcessing')
 const { MessageAttachment } = require('discord.js')
 const tempFileRemover = require('../../functions/tempFileRemover')
 

--- a/modules/canvasProcessing.js
+++ b/modules/canvasProcessing.js
@@ -21,6 +21,7 @@ module.exports = {
     const canvas = createCanvas(1100, 500)
     const ctx = canvas.getContext('2d')
 
+    ctx.strokeStyle = 'rgba(0,0,0,0)'
     // Establecer fondo del canvas
     let imgPath = ''
     if (database.welcomeImageCustomBackground && isValidUrl(database.welcomeImageCustomBackground) && isImageUrl(database.welcomeImageCustomBackground)) {
@@ -29,7 +30,6 @@ module.exports = {
       const scale = Math.max(canvas.width / background.width, canvas.height / background.height)
       ctx.drawImage(background, (canvas.width / 2) - (background.width / 2) * scale, (canvas.height / 2) - (background.height / 2) * scale, background.width * scale, background.height * scale)
       ctx.fillStyle = hexToRgba(database.welcomeImageCustomOverlayColor || '#272934', (database.welcomeImageCustomOpacity / 100))
-      ctx.strokeStyle = 'rgba(0,0,0,0)'
       roundRect(ctx, 25, 25, 1050, 450, 10, ctx.fillStyle, ctx.strokeStyle)
     } else {
       ctx.fillStyle = '#272934'
@@ -86,6 +86,7 @@ module.exports = {
     const ctx = canvas.getContext('2d')
 
     // Establecer fondo del canvas
+    ctx.strokeStyle = 'rgba(0,0,0,0)'
     let imgPath = ''
     if (guildConfig.levelsImageCustomBackground && isValidUrl(guildConfig.levelsImageCustomBackground) && isImageUrl(guildConfig.levelsImageCustomBackground)) {
       imgPath = guildConfig.levelsImageCustomBackground
@@ -95,7 +96,7 @@ module.exports = {
 
       // Establecer blured overlay
       ctx.fillStyle = hexToRgba(guildConfig.levelsImageCustomOverlayColor || '#272934', (guildConfig.levelsImageCustomOpacity / 100))
-      ctx.fillRect(25, 25, 1050, 270)
+      roundRect(ctx, 16, 16, 1068, 290, 10, ctx.fillStyle, ctx.strokeStyle)
     } else {
       ctx.fillStyle = '#272934'
       ctx.fillRect(0, 0, canvas.width, canvas.height)
@@ -125,17 +126,17 @@ module.exports = {
     // Añadir barra de progreso (backdrop)
 
     ctx.fillStyle = 'rgba(255,255,255, 0.3)'
-    ctx.fillRect(295, 200, 755, 70)
+    roundRect(ctx, 295, 200, 755, 70, 10, ctx.fillStyle, ctx.strokeStyle)
 
     // Añadir barra de progreso
 
     ctx.fillStyle = 'rgb(255,255,255)'
-    ctx.fillRect(295, 200, (Math.abs((member.levelData.memberExperience) / (((member.levelData.memberLevel * member.levelData.memberLevel) * guildConfig.levelsDifficulty) * 100)) * 755), 70)
+    roundRect(ctx, 295, 200, (Math.abs((member.levelData.memberExperience) / (((member.levelData.memberLevel * member.levelData.memberLevel) * guildConfig.levelsDifficulty) * 100)) * 755), 70, 10, ctx.fillStyle, ctx.strokeStyle)
 
     // Añadir avatar de usuario
 
     const avatar = await loadImage(member.user.displayAvatarURL({ format: 'png', size: 512 }))
-    ctx.drawImage(avatar, 50, 50, 220, 220)
+    ctx.drawImage(avatar, 57, 59, 204, 204)
 
     const buffer = canvas.toBuffer('image/png')
     writeFileSync(paths.attachmentSent, buffer)

--- a/modules/canvasProcessing.js
+++ b/modules/canvasProcessing.js
@@ -4,6 +4,7 @@ const randomstring = require('randomstring')
 const isValidUrl = require('is-valid-http-url')
 const isImageUrl = require('is-image-url')
 const hexToRgba = require('hex-to-rgba')
+const { millify } = require('millify')
 
 registerFont('./modules/sources/fonts/Montserrat/Montserrat-SemiBold.ttf', { family: 'Montserrat' })
 module.exports = {
@@ -65,6 +66,76 @@ module.exports = {
 
     const avatar = await loadImage(member.user.displayAvatarURL({ format: 'png', size: 512 }))
     ctx.drawImage(avatar, canvas.width / 2 - 100, 75, 200, 200)
+
+    const buffer = canvas.toBuffer('image/png')
+    writeFileSync(paths.attachmentSent, buffer)
+
+    return paths
+  },
+  generateRankCard: async (member, guildConfig) => {
+    const uniqueIdentifiers = {
+      userAvatar: randomstring.generate({ charset: 'alphabetic' }),
+      attachmentSent: randomstring.generate({ charset: 'alphabetic' })
+    }
+
+    const paths = {
+      attachmentSent: `./modules/temp/${uniqueIdentifiers.attachmentSent}.png`
+    }
+
+    const canvas = createCanvas(1100, 320)
+    const ctx = canvas.getContext('2d')
+
+    // Establecer fondo del canvas
+    let imgPath = ''
+    if (guildConfig.levelsImageCustomBackground && isValidUrl(guildConfig.levelsImageCustomBackground) && isImageUrl(guildConfig.levelsImageCustomBackground)) {
+      imgPath = guildConfig.levelsImageCustomBackground
+      const background = await loadImage(imgPath)
+      const scale = Math.max(canvas.width / background.width, canvas.height / background.height)
+      ctx.drawImage(background, (canvas.width / 2) - (background.width / 2) * scale, (canvas.height / 2) - (background.height / 2) * scale, background.width * scale, background.height * scale)
+
+      // Establecer blured overlay
+      ctx.fillStyle = hexToRgba(guildConfig.levelsImageCustomOverlayColor || '#272934', (guildConfig.levelsImageCustomOpacity / 100))
+      ctx.fillRect(25, 25, 1050, 270)
+    } else {
+      ctx.fillStyle = '#272934'
+      ctx.fillRect(0, 0, canvas.width, canvas.height)
+    }
+
+    // Escribir usuario
+    ctx.font = applyText(canvas, member.tag, 40)
+    ctx.textAlign = 'left'
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.8)'
+    ctx.fillText(`${member.tag}`, 295, 180, 500)
+
+    // Escribir nivel, experiencia y rango
+
+    ctx.font = '50px "Montserrat SemiBold"'
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.5)'
+    ctx.textAlign = 'right'
+    ctx.fillText(`Rank #${member.levelData.rank}  Level ${millify(member.levelData.memberLevel)}`, 1050, 100)
+
+    // Escribir progreso actual (actual/necesario)
+    const actualVSrequired = `${millify(member.levelData.memberExperience)} / ${millify(((member.levelData.memberLevel * member.levelData.memberLevel) * guildConfig.levelsDifficulty) * 100)} XP`
+
+    ctx.font = '30px "Montserrat SemiBold"'
+    ctx.textAlign = 'right'
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.8)'
+    ctx.fillText(actualVSrequired, 1050, 180)
+
+    // Añadir barra de progreso (backdrop)
+
+    ctx.fillStyle = 'rgba(255,255,255, 0.3)'
+    ctx.fillRect(295, 200, 755, 70)
+
+    // Añadir barra de progreso
+
+    ctx.fillStyle = 'rgb(255,255,255)'
+    ctx.fillRect(295, 200, (Math.abs((member.levelData.memberExperience) / (((member.levelData.memberLevel * member.levelData.memberLevel) * guildConfig.levelsDifficulty) * 100)) * 755), 70)
+
+    // Añadir avatar de usuario
+
+    const avatar = await loadImage(member.user.displayAvatarURL({ format: 'png', size: 512 }))
+    ctx.drawImage(avatar, 50, 50, 220, 220)
 
     const buffer = canvas.toBuffer('image/png')
     writeFileSync(paths.attachmentSent, buffer)

--- a/modules/levels.js
+++ b/modules/levels.js
@@ -1,14 +1,4 @@
 const talkedRecently = new Set()
-const { registerFont, createCanvas, loadImage } = require('canvas')
-const { writeFileSync } = require('fs')
-const StackBlur = require('stackblur-canvas')
-const randomstring = require('randomstring')
-const isValidUrl = require('is-valid-http-url')
-const isImageUrl = require('is-image-url')
-const { millify } = require('millify')
-const hexToRgba = require('hex-to-rgba')
-
-registerFont('./modules/sources/fonts/Montserrat/Montserrat-SemiBold.ttf', { family: 'Montserrat' })
 
 module.exports = {
   getMember: (client, member, callback) => {
@@ -99,77 +89,7 @@ module.exports = {
     }
     lRU.finish()
   },
-  generateRankCard: async (member, guildConfig) => {
-    const uniqueIdentifiers = {
-      userAvatar: randomstring.generate({ charset: 'alphabetic' }),
-      attachmentSent: randomstring.generate({ charset: 'alphabetic' })
-    }
 
-    const paths = {
-      attachmentSent: `./modules/temp/${uniqueIdentifiers.attachmentSent}.png`
-    }
-
-    const canvas = createCanvas(1100, 320)
-    const ctx = canvas.getContext('2d')
-
-    // Establecer fondo del canvas
-    let imgPath = ''
-    if (guildConfig.levelsImageCustomBackground && isValidUrl(guildConfig.levelsImageCustomBackground) && isImageUrl(guildConfig.levelsImageCustomBackground)) {
-      imgPath = guildConfig.levelsImageCustomBackground
-      const background = await loadImage(imgPath)
-      const scale = Math.max(canvas.width / background.width, canvas.height / background.height)
-      ctx.drawImage(background, (canvas.width / 2) - (background.width / 2) * scale, (canvas.height / 2) - (background.height / 2) * scale, background.width * scale, background.height * scale)
-
-      // Establecer blured overlay
-      ctx.fillStyle = hexToRgba(guildConfig.levelsImageCustomOverlayColor || '#272934', (guildConfig.levelsImageCustomOpacity / 100))
-      ctx.fillRect(25, 25, 1050, 270)
-      StackBlur.canvasRGBA(canvas, 25, 25, 1050, 270, guildConfig.levelsImageCustomBlur)
-    } else {
-      ctx.fillStyle = '#272934'
-      ctx.fillRect(0, 0, canvas.width, canvas.height)
-    }
-
-    // Escribir usuario
-    ctx.font = applyText(canvas, member.tag, 40)
-    ctx.textAlign = 'left'
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.8)'
-    ctx.fillText(`${member.tag}`, 295, 180, 500)
-
-    // Escribir nivel, experiencia y rango
-
-    ctx.font = '50px "Montserrat SemiBold"'
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.5)'
-    ctx.textAlign = 'right'
-    ctx.fillText(`Rank #${member.levelData.rank}  Level ${millify(member.levelData.memberLevel)}`, 1050, 100)
-
-    // Escribir progreso actual (actual/necesario)
-    const actualVSrequired = `${millify(member.levelData.memberExperience)} / ${millify(((member.levelData.memberLevel * member.levelData.memberLevel) * guildConfig.levelsDifficulty) * 100)} XP`
-
-    ctx.font = '30px "Montserrat SemiBold"'
-    ctx.textAlign = 'right'
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.8)'
-    ctx.fillText(actualVSrequired, 1050, 180)
-
-    // Añadir barra de progreso (backdrop)
-
-    ctx.fillStyle = 'rgba(255,255,255, 0.3)'
-    ctx.fillRect(295, 200, 755, 70)
-
-    // Añadir barra de progreso
-
-    ctx.fillStyle = 'rgb(255,255,255)'
-    ctx.fillRect(295, 200, (Math.abs((member.levelData.memberExperience) / (((member.levelData.memberLevel * member.levelData.memberLevel) * guildConfig.levelsDifficulty) * 100)) * 755), 70)
-
-    // Añadir avatar de usuario
-
-    const avatar = await loadImage(member.user.displayAvatarURL({ format: 'png', size: 512 }))
-    ctx.drawImage(avatar, 50, 50, 220, 220)
-
-    const buffer = canvas.toBuffer('image/png')
-    writeFileSync(paths.attachmentSent, buffer)
-
-    return paths
-  },
   getLeaderboard (client, guild, callback) {
     client.pool.query('SELECT * FROM `guildLevelsData` WHERE guild = ? ORDER BY memberLevel DESC, memberExperience DESC LIMIT 25', [guild.id], (err, members) => {
       if (err) client.logError(err)
@@ -177,15 +97,4 @@ module.exports = {
       else callback()
     })
   }
-}
-
-const applyText = (canvas, text, maxlimit) => {
-  const ctx = canvas.getContext('2d')
-  let fontSize = maxlimit || 100
-
-  do {
-    ctx.font = `${fontSize -= 1}px "Montserrat SemiBold"`
-  } while (ctx.measureText(text).width > canvas.width - 125)
-
-  return ctx.font
 }


### PR DESCRIPTION
- Revertir la acción de separación de 25ecb19 que ha llevado a separar el código de generación de las tarjetas de rango del módulo canvasProcessing.
- Añadir bordes redondeados a los diversos elementos de la composición y reducir tamaño del avatar.

Antiguas tarjetas de rango:
![](https://cdn.discordapp.com/attachments/926103260111179836/928779389372596234/XaysDyeOVBLrDYsYiklSWfyamsXLydsD.png)

Nuevas tarjetas de rango:
![](https://cdn.discordapp.com/attachments/926103260111179836/928779386059104347/imCnpLagomxItWHwTgagZWgjrjxHQIpe.png)